### PR TITLE
Distinguish between builtin filters/tests/globals/vars (fix #5 and #6)

### DIFF
--- a/resources/syntax/Jinja.sublime-syntax
+++ b/resources/syntax/Jinja.sublime-syntax
@@ -37,6 +37,33 @@ variables:
         |endfilter
       )\b
     )
+  builtin_filters: |-
+    (?x:\b(?:
+      abs|attr|batch|capitalize|center|default|dictsort|escape|filesizeformat|
+      first|float|forceescape|format|groupby|indent|int|join|last|length|list|
+      lower|map|max|min|pprint|random|reject|rejectattr|replace|reverse|round|
+      safe|select|selectattr|slice|sort|string|striptags|sum|title|tojson|trim
+      |truncate|unique|upper|urlencode|urlize|wordcount|wordwrap|xmlattr|e|d|
+      count
+    )\b)
+  builtin_tests: |-
+    (?x:\b(?:
+      boolean|callable|defined|divisibleby|equalto|eq|escaped|even|false|float|
+      ge|gt|greaterthan|in|integer|iterable|le|lower|lt|lessthan|mapping|ne|
+      none|number|odd|sameas|sequence|string|true|undefined|upper
+    )\b)
+  builtin_globals: |-
+    (?x:
+      \b(?:
+        range|lipsum|dict|cycler|joiner|namespace
+      )\b
+    )
+  builtin_vars: |-
+    (?x:
+      \b(?:
+        loop
+      )\b
+    )
 
 contexts:
   main:
@@ -219,8 +246,10 @@ contexts:
   match_identifiers:
     - match: \b_\b
       scope: variable.language.blank.jinja
-    - match: '{{identifiers}}'
-      scope: variable.other.jinja
+    - match: '({{builtin_vars}})|({{identifiers}})'
+      captures:
+        1: support.constant.jinja
+        2: variable.other.jinja
 
   dot_accessor:
     - match: \.
@@ -231,10 +260,13 @@ contexts:
       scope: punctuation.separator.sequence.jinja
 
   functions:
-    - match: (\w+)(\()
+    - match: (?:({{builtin_globals}})|(\w+))(\()
+      # The non-global matched functions should only be user-defined functions.
+      # User-defined tests and filters are matched greedily.
       captures:
-        1: variable.function.jinja
-        2: punctuation.section.arguments.begin.jinja
+        1: support.function.global.jinja
+        2: variable.function.jinja
+        3: punctuation.section.arguments.begin.jinja
       push:
         - meta_content_scope: meta.function-call.arguments.jinja
         - match: \)
@@ -322,6 +354,20 @@ contexts:
         - include: item_seperator
 
   logical_operators:
+    - match: '\b(is) +(not)?\b'
+      captures:
+        1: keyword.operator.word.jinja
+        2: keyword.operator.word.jinja
+      # Greedily match the applied test to scope it.
+      push:
+        - match: '\b(?:({{builtin_tests}})|(\w+))\b'
+          captures:
+            1: support.function.test.jinja
+            2: variable.function.test.jinja
+          pop: true
+        - match: '\S'
+          scope: invalid.illegal.missing-test.jinja
+          pop: true
     - match: '{{logical_operators}}'
       scope: keyword.operator.word.jinja
 
@@ -385,8 +431,22 @@ contexts:
 
   ###[ Operators ]##################################################################
 
-  operators: [
-    {match: \|   , scope: keyword.operator.logical.pipe.jinja},
+  operators:
+    - match: \|
+      scope: keyword.operator.logical.pipe.jinja
+      # Greedily match the applied filter to scope it as a filter.
+      push:
+        - match: '\b(?:({{builtin_filters}})|({{identifiers}}))\b'
+          captures:
+            1: support.function.filter.jinja
+            2: variable.function.filter.jinja
+          pop: true
+        - match: '\S'
+          scope: invalid.illegal.missing-filter.jinja
+          pop: true
+    - include: other_operators
+
+  other_operators: [
     {match: \>=  , scope: keyword.operator.comparison.jinja},
     {match: \~   , scope: keyword.operator.concatenation.jinja},
     {match: \<=  , scope: keyword.operator.comparison.jinja},

--- a/resources/syntax/Jinja.sublime-syntax
+++ b/resources/syntax/Jinja.sublime-syntax
@@ -38,20 +38,24 @@ variables:
       )\b
     )
   builtin_filters: |-
-    (?x:\b(?:
-      abs|attr|batch|capitalize|center|default|dictsort|escape|filesizeformat|
-      first|float|forceescape|format|groupby|indent|int|join|last|length|list|
-      lower|map|max|min|pprint|random|reject|rejectattr|replace|reverse|round|
-      safe|select|selectattr|slice|sort|string|striptags|sum|title|tojson|trim
-      |truncate|unique|upper|urlencode|urlize|wordcount|wordwrap|xmlattr|e|d|
-      count
-    )\b)
+    (?x:
+      \b(?:
+        abs|attr|batch|capitalize|center|default|dictsort|escape|filesizeformat|
+        first|float|forceescape|format|groupby|indent|int|join|last|length|list|
+        lower|map|max|min|pprint|random|reject|rejectattr|replace|reverse|round|
+        safe|select|selectattr|slice|sort|string|striptags|sum|title|tojson|trim
+        |truncate|unique|upper|urlencode|urlize|wordcount|wordwrap|xmlattr|e|d|
+        count
+      )\b
+    )
   builtin_tests: |-
-    (?x:\b(?:
-      boolean|callable|defined|divisibleby|equalto|eq|escaped|even|false|float|
-      ge|gt|greaterthan|in|integer|iterable|le|lower|lt|lessthan|mapping|ne|
-      none|number|odd|sameas|sequence|string|true|undefined|upper
-    )\b)
+    (?x:
+      \b(?:
+        boolean|callable|defined|divisibleby|equalto|eq|escaped|even|false|float|
+        ge|gt|greaterthan|in|integer|iterable|le|lower|lt|lessthan|mapping|ne|
+        none|number|odd|sameas|sequence|string|true|undefined|upper
+      )\b
+    )
   builtin_globals: |-
     (?x:
       \b(?:
@@ -354,7 +358,7 @@ contexts:
         - include: item_seperator
 
   logical_operators:
-    - match: '\b(is) +(not)?\b'
+    - match: '\b(is)\s+(not)?\b'
       captures:
         1: keyword.operator.word.jinja
         2: keyword.operator.word.jinja

--- a/resources/syntax/Jinja.sublime-syntax
+++ b/resources/syntax/Jinja.sublime-syntax
@@ -16,7 +16,7 @@ variables:
   digit: '[0-9]'
   integers: '(?:{{digit}}*_)?{{digit}}+'
   floats: '(?:(?:{{digit}}*_?)*)?(\.){{digit}}+(?:[eE]{{digit}}*)?'
-  identifiers: '[a-zA-Z_]+(?:{{digit}}*)?'
+  identifiers: '[a-zA-Z_][a-zA-Z0-9_]*'
 
   trim_block: '(?:[+-])'
   logical_operators: \b(?:and|or|not|in|is)\b

--- a/resources/syntax/tests/syntax_test_expression.jinja
+++ b/resources/syntax/tests/syntax_test_expression.jinja
@@ -155,3 +155,6 @@
 
    {{ my_loop.index }}
 ##    ^^^^^^^ variable.other.jinja
+
+   {{ subl_cfg.config | dict2items }}
+##                      ^^^^^^^^^^ variable.function.filter.jinja

--- a/resources/syntax/tests/syntax_test_expression.jinja
+++ b/resources/syntax/tests/syntax_test_expression.jinja
@@ -72,19 +72,18 @@
 ##                                ^^^ constant.numeric.integer.jinja
 ##                                          ^^^^^^^ constant.numeric.float.jinja
 
-    {{ not in is and or }}
+    {{ not in and or }}
 ##     ^^^ keyword.operator.word.jinja
 ##         ^^ keyword.operator.word.jinja
-##            ^^ keyword.operator.word.jinja
-##               ^^^ keyword.operator.word.jinja
-##                   ^^ keyword.operator.word.jinja
+##            ^^^ keyword.operator.word.jinja
+##                ^^ keyword.operator.word.jinja
 
     {{ "foo {bar} baz" }}
 ##          ^^^^^ constant.other.placeholder.jinja
 ##          ^ punctuation.definition.placeholder.begin.jinja
 ##              ^ punctuation.definition.placeholder.end.jinja
 ##           ^^^ variable.other.jinja
-   
+
     {{ "foo {1 + 2.3} baz" }}
 ##           ^ constant.numeric.integer.jinja
 ##               ^^^ constant.numeric.float.jinja
@@ -103,3 +102,56 @@
 ##                   ^^ constant.character.escape.jinja
 ##                                         ^^ constant.character.escape.jinja
 ##                                            ^^ constant.character.escape.jinja
+
+   {{ foo is defined }}
+##    ^^^ variable.other.jinja
+##        ^^ keyword.operator.word.jinja
+##           ^^^^^^^ support.function.test.jinja
+
+   {{ foo is my_test }}
+##    ^^^ variable.other.jinja
+##        ^^ keyword.operator.word.jinja
+##           ^^^^^^^ variable.function.test.jinja
+
+   {{ foo is not defined }}
+##    ^^^ variable.other.jinja
+##        ^^ keyword.operator.word.jinja
+##           ^^^ keyword.operator.word.jinja
+##               ^^^^^^^ support.function.test.jinja
+
+   {{ foo is not my_test }}
+##    ^^^ variable.other.jinja
+##        ^^ keyword.operator.word.jinja
+##           ^^^ keyword.operator.word.jinja
+##               ^^^^^^^ variable.function.test.jinja
+
+   {{ foo | list }}
+##    ^^^ variable.other.jinja
+##        ^ keyword.operator.logical.pipe.jinja
+##          ^^^^ support.function.filter.jinja
+
+   {{ foo | my_list }}
+##    ^^^ variable.other.jinja
+##        ^ keyword.operator.logical.pipe.jinja
+##          ^^^^^^^ variable.function.filter.jinja
+
+   {{ foo | default([]) | list }}
+##    ^^^ variable.other.jinja
+##        ^ keyword.operator.logical.pipe.jinja
+##          ^^^^^^^ support.function.filter.jinja
+##                      ^ keyword.operator.logical.pipe.jinja
+##                        ^^^^ support.function.filter.jinja
+
+   {{ foo | int is in range(10) }}
+##    ^^^ variable.other.jinja
+##        ^ keyword.operator.logical.pipe.jinja
+##          ^^^ support.function.filter.jinja
+##              ^^ keyword.operator.word.jinja
+##                 ^^ support.function.test.jinja
+##                    ^^^^^ support.function.global.jinja
+
+   {{ loop.index }}
+##    ^^^^ support.constant.jinja
+
+   {{ my_loop.index }}
+##    ^^^^^^^ variable.other.jinja

--- a/resources/syntax/tests/syntax_test_regressions.jinja
+++ b/resources/syntax/tests/syntax_test_regressions.jinja
@@ -1,0 +1,15 @@
+## SYNTAX TEST "Packages/BetterJinja/resources/syntax/Jinja.sublime-syntax"
+
+## Issue #5
+   {{ poetry_bin_path | default('/usr/local/bin/poetry') }}
+##                      ^^^^^^^ support.function.filter.jinja
+
+## Issue #6
+   {% if test is false %}
+##               ^^^^^ support.function.test.jinja
+   {% if test eq false %}
+##               ^^^^^ constant.language.jinja
+   {% if 1 is in [1, 2] %}
+##            ^^ support.function.test.jinja
+   {% if 1 in [1, 2] %}
+##         ^^ keyword.operator.word.jinja

--- a/resources/syntax/tests/syntax_test_statement_blocks.jinja
+++ b/resources/syntax/tests/syntax_test_statement_blocks.jinja
@@ -15,13 +15,12 @@
 ## ^^^ meta.statement.jinja punctuation.definition.statement.begin.jinja
 ##      ^^^ meta.statement.jinja punctuation.definition.statement.end.jinja
 
-   {% if elif else endif is scoped %}
+   {% if elif else endif scoped %}
 ##    ^^ keyword.control.conditional.if.jinja
 ##       ^^^^ keyword.control.conditional.elseif.jinja
 ##            ^^^^ keyword.control.conditional.else.jinja
 ##                 ^^^^^ keyword.other.endtag.jinja
-##                       ^^ keyword.operator.word.jinja
-##                          ^^^^^^ keyword.other.tag.jinja
+##                       ^^^^^^ keyword.other.tag.jinja
 
    {% for item in items endfor %}
 ##    ^^^ keyword.control.loop.for.jinja
@@ -96,8 +95,9 @@
    {%- - %}
 ##     ^ invalid.illegal.jinja
 
-    {% | %}
+    {% | list %}
 ##     ^ keyword.operator.logical.pipe.jinja
+##       ^^^^ support.function.filter.jinja
 
     {% function(arg1 = value1, arg2 = value2) %}
 ##     ^^^^^^^^ variable.function.jinja
@@ -106,3 +106,6 @@
 ##                   ^ keyword.operator.assignment.jinja
 ##                           ^ punctuation.separator.parameters.twig
 ##                                          ^ punctuation.section.arguments.end.jinja
+
+   {% set ns = namespace() %}
+##             ^^^^^^^^^ support.function.global.jinja


### PR DESCRIPTION
This commit fixes #5 by marking applied filters/tests as functions or support functions, depending on whether they're builtin. In addition, it marks built-in global functions (e.g., namespace) and built-in variables (for now, `loop`) as support.
Simultaneously, this commit fixes #6 by greedily matching applied tests and scoping them appropriately.

New test cases added to verify correct behaviour.

Fixes: #5 and #6 

In addition, this fixes the identifier naming scheme s.t. identifiers containing digits are allowed (e.g., `dict2items`). Identifiers starting with a digit are still illegal.