### PR TITLE
[WIP] Embedding Jinja2 into more syntaxes

### DIFF
--- a/resources/syntax/Jinja Bash.sublime-syntax
+++ b/resources/syntax/Jinja Bash.sublime-syntax
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+name: bash (Jinja2)
+scope: source.shell.bash.jinja
 file_extensions:
   - sh.jinja
   - sh.jinja2
@@ -71,13 +73,12 @@ contexts:
   main:
     - match: ''
       push: Packages/ShellScript/Bash.sublime-syntax
+      lines: false
       with_prototype:
-        - match: (?=##|\{\{|\{%|\{#)
+        - match: (?=\{(?:\{|%|#))
           push:
             - meta_scope: source.shell.bash source.jinja.embedded
             - clear_scopes: true
             - include: Jinja.sublime-syntax#main
             - match: ''
               pop: true
-name: bash (Jinja2)
-scope: source.shell.bash.jinja

--- a/resources/syntax/Jinja Bash.sublime-syntax
+++ b/resources/syntax/Jinja Bash.sublime-syntax
@@ -67,7 +67,6 @@ file_extensions:
   - .eclass.jinja
   - .eclass.jinja2
   - .eclass.j2
-scope: source.shell.bash.jinja
 contexts:
   main:
     - match: ''
@@ -80,4 +79,5 @@ contexts:
             - include: Jinja.sublime-syntax#main
             - match: ''
               pop: true
-name: Jinja (Bourne Again Shell (bash))
+name: bash (Jinja2)
+scope: source.shell.bash.jinja

--- a/resources/syntax/Jinja Bash.sublime-syntax
+++ b/resources/syntax/Jinja Bash.sublime-syntax
@@ -1,0 +1,83 @@
+%YAML 1.2
+---
+file_extensions:
+  - sh.jinja
+  - sh.jinja2
+  - sh.j2
+  - bash.jinja
+  - bash.jinja2
+  - bash.j2
+  - zsh.jinja
+  - zsh.jinja2
+  - zsh.j2
+  - ash.jinja
+  - ash.jinja2
+  - ash.j2
+  - .bash_aliases.jinja
+  - .bash_aliases.jinja2
+  - .bash_aliases.j2
+  - .bash_completions.jinja
+  - .bash_completions.jinja2
+  - .bash_completions.j2
+  - .bash_functions.jinja
+  - .bash_functions.jinja2
+  - .bash_functions.j2
+  - .bash_login.jinja
+  - .bash_login.jinja2
+  - .bash_login.j2
+  - .bash_logout.jinja
+  - .bash_logout.jinja2
+  - .bash_logout.j2
+  - .bash_profile.jinja
+  - .bash_profile.jinja2
+  - .bash_profile.j2
+  - .bash_variables.jinja
+  - .bash_variables.jinja2
+  - .bash_variables.j2
+  - .bashrc.jinja
+  - .bashrc.jinja2
+  - .bashrc.j2
+  - .profile.jinja
+  - .profile.jinja2
+  - .profile.j2
+  - .textmate_init.jinja
+  - .textmate_init.jinja2
+  - .textmate_init.j2
+  - .zlogin.jinja
+  - .zlogin.jinja2
+  - .zlogin.j2
+  - .zlogout.jinja
+  - .zlogout.jinja2
+  - .zlogout.j2
+  - .zprofile.jinja
+  - .zprofile.jinja2
+  - .zprofile.j2
+  - .zshenv.jinja
+  - .zshenv.jinja2
+  - .zshenv.j2
+  - .zshrc.jinja
+  - .zshrc.jinja2
+  - .zshrc.j2
+  - PKGBUILD.jinja
+  - PKGBUILD.jinja2
+  - PKGBUILD.j2
+  - .ebuild.jinja
+  - .ebuild.jinja2
+  - .ebuild.j2
+  - .eclass.jinja
+  - .eclass.jinja2
+  - .eclass.j2
+scope: source.shell.bash.jinja
+contexts:
+  main:
+    - match: ''
+      push: Packages/ShellScript/Bash.sublime-syntax
+      with_prototype:
+        - match: (?=##|\{\{|\{%|\{#)
+          push:
+            - meta_scope: source.shell.bash source.jinja.embedded
+            - clear_scopes: true
+            - include: Jinja.sublime-syntax#main
+            - match: ''
+              pop: true
+name: Jinja (Bourne Again Shell (bash))

--- a/resources/syntax/Jinja Bash.sublime-syntax.yaml-macros
+++ b/resources/syntax/Jinja Bash.sublime-syntax.yaml-macros
@@ -2,5 +2,7 @@
 %TAG ! tag:yaml-macros:YAMLMacros.lib.include,YAMLMacros.lib.extend,embed:
 ---
 !apply
-- !base_syntax Packages/ShellScript/Bash.sublime-syntax
+- !base_syntax
+  path: Packages/ShellScript/Bash.sublime-syntax
+  name: bash
 - !include embed-base.yaml-macros

--- a/resources/syntax/Jinja Bash.sublime-syntax.yaml-macros
+++ b/resources/syntax/Jinja Bash.sublime-syntax.yaml-macros
@@ -1,0 +1,6 @@
+%YAML 1.2
+%TAG ! tag:yaml-macros:YAMLMacros.lib.include,YAMLMacros.lib.extend,embed:
+---
+!apply
+- !base_syntax Packages/ShellScript/Bash.sublime-syntax
+- !include embed-base.yaml-macros

--- a/resources/syntax/Jinja Bash.sublime-syntax.yaml-macros
+++ b/resources/syntax/Jinja Bash.sublime-syntax.yaml-macros
@@ -5,4 +5,5 @@
 - !base_syntax
   path: Packages/ShellScript/Bash.sublime-syntax
   name: bash
+  line_statements: false
 - !include embed-base.yaml-macros

--- a/resources/syntax/Jinja HTML.sublime-syntax
+++ b/resources/syntax/Jinja HTML.sublime-syntax
@@ -13,11 +13,17 @@ file_extensions:
   - xhtml.jinja
   - xhtml.jinja2
   - xhtml.j2
-scope: text.html.basic.jinja
 contexts:
   main:
     - match: ''
       push: Packages/HTML/HTML.sublime-syntax
       with_prototype:
-        - include: Jinja.sublime-syntax#main
-name: Jinja (HTML)
+        - match: (?=##|\{\{|\{%|\{#)
+          push:
+            - meta_scope: text.html.basic source.jinja.embedded
+            - clear_scopes: true
+            - include: Jinja.sublime-syntax#main
+            - match: ''
+              pop: true
+name: HTML (Jinja2)
+scope: text.html.basic.jinja

--- a/resources/syntax/Jinja HTML.sublime-syntax
+++ b/resources/syntax/Jinja HTML.sublime-syntax
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+file_extensions:
+  - html.jinja
+  - html.jinja2
+  - html.j2
+  - htm.jinja
+  - htm.jinja2
+  - htm.j2
+  - shtml.jinja
+  - shtml.jinja2
+  - shtml.j2
+  - xhtml.jinja
+  - xhtml.jinja2
+  - xhtml.j2
+scope: text.html.basic.jinja
+contexts:
+  main:
+    - match: ''
+      push: Packages/HTML/HTML.sublime-syntax
+      with_prototype:
+        - include: Jinja.sublime-syntax#main
+name: Jinja (HTML)

--- a/resources/syntax/Jinja HTML.sublime-syntax
+++ b/resources/syntax/Jinja HTML.sublime-syntax
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+name: HTML (Jinja2)
+scope: text.html.basic.jinja
 file_extensions:
   - html.jinja
   - html.jinja2
@@ -17,13 +19,12 @@ contexts:
   main:
     - match: ''
       push: Packages/HTML/HTML.sublime-syntax
+      lines: true
       with_prototype:
-        - match: (?=##|\{\{|\{%|\{#)
+        - match: (?=##?|\{\{|\{%|\{#)
           push:
             - meta_scope: text.html.basic source.jinja.embedded
             - clear_scopes: true
             - include: Jinja.sublime-syntax#main
             - match: ''
               pop: true
-name: HTML (Jinja2)
-scope: text.html.basic.jinja

--- a/resources/syntax/Jinja HTML.sublime-syntax.yaml-macros
+++ b/resources/syntax/Jinja HTML.sublime-syntax.yaml-macros
@@ -1,0 +1,6 @@
+%YAML 1.2
+%TAG ! tag:yaml-macros:YAMLMacros.lib.include,YAMLMacros.lib.extend,embed:
+---
+!apply
+- !base_syntax Packages/HTML/HTML.sublime-syntax
+- !include embed-base.yaml-macros

--- a/resources/syntax/Jinja JSON.sublime-syntax
+++ b/resources/syntax/Jinja JSON.sublime-syntax
@@ -1,5 +1,7 @@
 %YAML 1.2
 ---
+name: JSON (Jinja2)
+scope: source.json.jinja
 file_extensions:
   - json.jinja
   - json.jinja2
@@ -47,13 +49,12 @@ contexts:
   main:
     - match: ''
       push: Packages/JavaScript/JSON.sublime-syntax
+      lines: true
       with_prototype:
-        - match: (?=##|\{\{|\{%|\{#)
+        - match: (?=##?|\{\{|\{%|\{#)
           push:
             - meta_scope: source.json source.jinja.embedded
             - clear_scopes: true
             - include: Jinja.sublime-syntax#main
             - match: ''
               pop: true
-name: JSON (Jinja2)
-scope: source.json.jinja

--- a/resources/syntax/Jinja JSON.sublime-syntax
+++ b/resources/syntax/Jinja JSON.sublime-syntax
@@ -43,7 +43,6 @@ file_extensions:
   - Pipfile.lock.jinja
   - Pipfile.lock.jinja2
   - Pipfile.lock.j2
-scope: source.json.jinja
 contexts:
   main:
     - match: ''
@@ -56,4 +55,5 @@ contexts:
             - include: Jinja.sublime-syntax#main
             - match: ''
               pop: true
-name: Jinja (JSON)
+name: JSON (Jinja2)
+scope: source.json.jinja

--- a/resources/syntax/Jinja JSON.sublime-syntax
+++ b/resources/syntax/Jinja JSON.sublime-syntax
@@ -1,0 +1,59 @@
+%YAML 1.2
+---
+file_extensions:
+  - json.jinja
+  - json.jinja2
+  - json.j2
+  - sublime-settings.jinja
+  - sublime-settings.jinja2
+  - sublime-settings.j2
+  - sublime-menu.jinja
+  - sublime-menu.jinja2
+  - sublime-menu.j2
+  - sublime-keymap.jinja
+  - sublime-keymap.jinja2
+  - sublime-keymap.j2
+  - sublime-mousemap.jinja
+  - sublime-mousemap.jinja2
+  - sublime-mousemap.j2
+  - sublime-theme.jinja
+  - sublime-theme.jinja2
+  - sublime-theme.j2
+  - sublime-build.jinja
+  - sublime-build.jinja2
+  - sublime-build.j2
+  - sublime-project.jinja
+  - sublime-project.jinja2
+  - sublime-project.j2
+  - sublime-completions.jinja
+  - sublime-completions.jinja2
+  - sublime-completions.j2
+  - sublime-commands.jinja
+  - sublime-commands.jinja2
+  - sublime-commands.j2
+  - sublime-macro.jinja
+  - sublime-macro.jinja2
+  - sublime-macro.j2
+  - sublime-color-scheme.jinja
+  - sublime-color-scheme.jinja2
+  - sublime-color-scheme.j2
+  - ipynb.jinja
+  - ipynb.jinja2
+  - ipynb.j2
+  - Pipfile.lock.jinja
+  - Pipfile.lock.jinja2
+  - Pipfile.lock.j2
+scope: source.json.jinja
+contexts:
+  main:
+    - match: ''
+      push: Packages/JavaScript/JSON.sublime-syntax
+      with_prototype:
+        - match: (?=##|\{\{|\{%|\{#)
+          push:
+            - meta_scope: source.json source.jinja.embedded
+            - clear_scopes: true
+            - include: Jinja.sublime-syntax#main
+            - match: ''
+              pop: true
+name: Jinja (JSON)

--- a/resources/syntax/Jinja JSON.sublime-syntax.yaml-macros
+++ b/resources/syntax/Jinja JSON.sublime-syntax.yaml-macros
@@ -1,0 +1,6 @@
+%YAML 1.2
+%TAG ! tag:yaml-macros:YAMLMacros.lib.include,YAMLMacros.lib.extend,embed:
+---
+!apply
+- !base_syntax Packages/JavaScript/JSON.sublime-syntax
+- !include embed-base.yaml-macros

--- a/resources/syntax/Jinja.sublime-syntax
+++ b/resources/syntax/Jinja.sublime-syntax
@@ -4,12 +4,6 @@ file_extensions:
   - j2
   - jinja
   - jinja2
-  - html.j2
-  - html.jinja
-  - html.jinja2
-  - htm.j2
-  - htm.jinja
-  - htm.jinja2
 scope: text.jinja
 
 variables:
@@ -40,13 +34,10 @@ variables:
 
 contexts:
   main:
-    - match: ""
-      push: "Packages/HTML/HTML.sublime-syntax"
-      with_prototype:
-        - include: statement_blocks
-        - include: expression_blocks
-        - include: comments
-        - include: line_statements
+    - include: statement_blocks
+    - include: expression_blocks
+    - include: comments
+    - include: line_statements
 
   ###[ Line Statements ]##################################################################
 

--- a/resources/syntax/embed-base.yaml-macros
+++ b/resources/syntax/embed-base.yaml-macros
@@ -28,8 +28,6 @@ file_extensions: !add_suffix
 contexts:
   main:
     - match: ""
-      # Get the path to the syntax from the meta-variables, e.g.
-      # Packages/HTML/HTML.sublime-syntax
       push: !argument embedding_syntax_path
       with_prototype:
         - match: (?=##|\{\{|\{%|\{#)

--- a/resources/syntax/embed-base.yaml-macros
+++ b/resources/syntax/embed-base.yaml-macros
@@ -29,8 +29,12 @@ contexts:
   main:
     - match: ""
       push: !argument embedding_syntax_path
+      lines: !argument enable_line_statements
       with_prototype:
-        - match: (?=##|\{\{|\{%|\{#)
+        - match: !if
+            condition: !argument enable_line_statements
+            then: '(?=##?|\{\{|\{%|\{#)'
+            else: '(?=\{(?:\{|%|#))'
           push:
             - meta_scope: !format '{embedding_scope} source.jinja.embedded'
             - clear_scopes: true

--- a/resources/syntax/embed-base.yaml-macros
+++ b/resources/syntax/embed-base.yaml-macros
@@ -9,7 +9,7 @@
 # meta-variables (see the per-syntax macros). In essence, this formats the name
 # of the syntax as "Jinja (HTML)" if the host language is HTML, Jinja (JSON)
 # for JSON, etc. Scopes are analogous, and become "source.html.basic.jinja" etc
-name: !format 'Jinja ({embedding_language})'
+name: !format '{embedding_language} (Jinja2)'
 scope: !format '{embedding_scope}.jinja'
 # Add the .jinja, .jinja2, .j2 suffixes to each file_extension listed in the
 # host syntax' file extensions, through a custom macro.

--- a/resources/syntax/embed-base.yaml-macros
+++ b/resources/syntax/embed-base.yaml-macros
@@ -1,0 +1,25 @@
+%YAML 1.2
+%TAG ! tag:yaml-macros:YAMLMacros.lib.extend,YAMLMacros.lib.arguments,embed:
+---
+!merge
+name: !format 'Jinja ({embedding_language})'
+scope: !format '{embedding_scope}.jinja'
+file_extensions: !add_suffix
+  source: !argument embedding_suffixes
+  suffix:
+    - jinja
+    - jinja2
+    - j2
+
+contexts:
+  main:
+    - match: ""
+      push: !argument embedding_syntax_path
+      with_prototype:
+        - match: (?=##|\{\{|\{%|\{#)
+          push:
+            - meta_scope: !format '{embedding_scope} source.jinja.embedded'
+            - clear_scopes: true
+            - include: Jinja.sublime-syntax#main
+            - match: ''
+              pop: true

--- a/resources/syntax/embed-base.yaml-macros
+++ b/resources/syntax/embed-base.yaml-macros
@@ -1,19 +1,35 @@
 %YAML 1.2
 %TAG ! tag:yaml-macros:YAMLMacros.lib.extend,YAMLMacros.lib.arguments,embed:
 ---
+# Merge the content of this file into an existing YAML collection. In our case,
+# this will be merged onto an empty file.
 !merge
+
+# !format => str.format the given string. Arguments are taken from the
+# meta-variables (see the per-syntax macros). In essence, this formats the name
+# of the syntax as "Jinja (HTML)" if the host language is HTML, Jinja (JSON)
+# for JSON, etc. Scopes are analogous, and become "source.html.basic.jinja" etc
 name: !format 'Jinja ({embedding_language})'
 scope: !format '{embedding_scope}.jinja'
+# Add the .jinja, .jinja2, .j2 suffixes to each file_extension listed in the
+# host syntax' file extensions, through a custom macro.
 file_extensions: !add_suffix
+  # The source list of file extensions, retrieved from the meta-variables
+  # through !argument.
   source: !argument embedding_suffixes
+  # The list of suffixes to append.
   suffix:
     - jinja
     - jinja2
     - j2
 
+# Main boilerplate embedding syntax. Will be instantiated with the appropriate
+# values on a per-syntax basis.
 contexts:
   main:
     - match: ""
+      # Get the path to the syntax from the meta-variables, e.g.
+      # Packages/HTML/HTML.sublime-syntax
       push: !argument embedding_syntax_path
       with_prototype:
         - match: (?=##|\{\{|\{%|\{#)

--- a/resources/syntax/embed.py
+++ b/resources/syntax/embed.py
@@ -6,21 +6,28 @@ from YAMLMacros.lib.include import include_resource
 
 
 @raw_macro
-def base_syntax(path, arguments):
-    """Import variables from the base syntax to extend.
+def base_syntax(path, arguments, eval, name=None):
+    """
+    Import variables from the base syntax to extend.
 
-    :param      path:       The path to the base syntax, e.g.
-                            Packages/HTML/HTML.sublime-syntax
-    :type       path:       str
-    :param      arguments:  Arguments injected by YAMLMacros
-    :type       arguments:  dict
+    :param      path:             The path to the base syntax, e.g.
+                                  Packages/HTML/HTML.sublime-syntax
+    :type       path:             str
+    :param      arguments:        Arguments injected by YAMLMacros
+    :type       arguments:        dict
+    :param      eval:             Evaluation function injected by YAMLMacros
+    :type       eval:             callable
+    :param      name:             The name of the syntax, None for autodetect.
+    :type       name:             str|None
 
     :returns:   YAML element after macro transformation. This is an empty dict
                 so that it can be used in an `apply` macro.
     :rtype:     dict
     """
     syntax_yaml = include_resource(path.value)
-    arguments['embedding_language'] = syntax_yaml.get('name', '')
+    if name is not None:
+        name = eval(name)
+    arguments['embedding_language'] = name or syntax_yaml.get('name', '')
     arguments['embedding_suffixes'] = syntax_yaml.get('file_extensions', [])
     arguments['embedding_syntax_path'] = path.value
     arguments['embedding_scope'] = syntax_yaml.get('scope', '')

--- a/resources/syntax/embed.py
+++ b/resources/syntax/embed.py
@@ -1,3 +1,4 @@
+"""Custom macros for syntax embedding."""
 from itertools import product
 
 from YAMLMacros.api import raw_macro
@@ -6,6 +7,18 @@ from YAMLMacros.lib.include import include_resource
 
 @raw_macro
 def base_syntax(path, arguments):
+    """Import variables from the base syntax to extend.
+
+    :param      path:       The path to the base syntax, e.g.
+                            Packages/HTML/HTML.sublime-syntax
+    :type       path:       str
+    :param      arguments:  Arguments injected by YAMLMacros
+    :type       arguments:  dict
+
+    :returns:   YAML element after macro transformation. This is an empty dict
+                so that it can be used in an `apply` macro.
+    :rtype:     dict
+    """
     syntax_yaml = include_resource(path.value)
     arguments['embedding_language'] = syntax_yaml.get('name', '')
     arguments['embedding_suffixes'] = syntax_yaml.get('file_extensions', [])
@@ -16,6 +29,19 @@ def base_syntax(path, arguments):
 
 @raw_macro
 def add_suffix(source, suffix, eval):
+    """Add a dot-separated suffix to a list of strings.
+
+    :param      source:  List of source strings to suffix.
+    :type       source:  List[str]
+    :param      suffix:  List of suffixes to append.
+    :type       suffix:  str|List[str]
+    :param      eval:    Evaluation function injected by YAMLMacros
+    :type       eval:    callable
+
+    :returns:   List of suffixed strings. Every element in the source list is
+                suffixed by every element in the suffix list.
+    :rtype:     List[str]
+    """
     suffix = eval(suffix)
     source = eval(source)
     if not isinstance(suffix, list):

--- a/resources/syntax/embed.py
+++ b/resources/syntax/embed.py
@@ -1,4 +1,5 @@
 """Custom macros for syntax embedding."""
+from collections import OrderedDict
 from itertools import product
 
 from YAMLMacros.api import raw_macro
@@ -6,7 +7,7 @@ from YAMLMacros.lib.include import include_resource
 
 
 @raw_macro
-def base_syntax(path, arguments, eval, name=None):
+def base_syntax(path, arguments, eval, name=None, line_statements=True):
     """
     Import variables from the base syntax to extend.
 
@@ -19,6 +20,10 @@ def base_syntax(path, arguments, eval, name=None):
     :type       eval:             callable
     :param      name:             The name of the syntax, None for autodetect.
     :type       name:             str|None
+    :param      line_statements:  Whether or not to use line statements.
+                                  Set to False if the host language uses `#`
+                                  for comments.
+    :type       line_statements:  boolean
 
     :returns:   YAML element after macro transformation. This is an empty dict
                 so that it can be used in an `apply` macro.
@@ -27,11 +32,15 @@ def base_syntax(path, arguments, eval, name=None):
     syntax_yaml = include_resource(path.value)
     if name is not None:
         name = eval(name)
+    if not isinstance(line_statements, bool):
+        line_statements = eval(line_statements)
+
     arguments['embedding_language'] = name or syntax_yaml.get('name', '')
     arguments['embedding_suffixes'] = syntax_yaml.get('file_extensions', [])
     arguments['embedding_syntax_path'] = path.value
     arguments['embedding_scope'] = syntax_yaml.get('scope', '')
-    return {}
+    arguments['enable_line_statements'] = line_statements
+    return OrderedDict()
 
 
 @raw_macro

--- a/resources/syntax/embed.py
+++ b/resources/syntax/embed.py
@@ -1,0 +1,24 @@
+from itertools import product
+
+from YAMLMacros.api import raw_macro
+from YAMLMacros.lib.include import include_resource
+
+
+@raw_macro
+def base_syntax(path, arguments):
+    syntax_yaml = include_resource(path.value)
+    arguments['embedding_language'] = syntax_yaml.get('name', '')
+    arguments['embedding_suffixes'] = syntax_yaml.get('file_extensions', [])
+    arguments['embedding_syntax_path'] = path.value
+    arguments['embedding_scope'] = syntax_yaml.get('scope', '')
+    return {}
+
+
+@raw_macro
+def add_suffix(source, suffix, eval):
+    suffix = eval(suffix)
+    source = eval(source)
+    if not isinstance(suffix, list):
+        suffix = [suffix]
+
+    return ['{}.{}'.format(base, ext) for base, ext in product(source, suffix)]

--- a/resources/syntax/syntax-template.sublime-syntax.yaml-macros
+++ b/resources/syntax/syntax-template.sublime-syntax.yaml-macros
@@ -6,11 +6,19 @@
 
 # We will apply the following macros.
 !apply
+
 # Mark which base (host) syntax we shall use using its path, e.g.
 # Packages/HTML/HTML.sublime-syntax
 # This will extract the necessary information from the syntax and set them
 # as meta-variables.
 - !base_syntax path/to/syntax.sublime-syntax
+# Alternatively:
+- !base_syntax
+  path: path/to/syntax.sublime-syntax
+  name: Syntax  # Use this to override automatic detection of syntax name.
+                # E.g. "bash" -> "bash (Jinja2)" instead of
+                # "Bourne Again Shell (bash) (Jinja2)"
+
 # Include the base template, whose macros will be automatically expanded upon
 # import. The resulting YAML will be merged on top of an empty dict and will be
 # written out to the name of this file, minus the `.yaml-macros` extension.

--- a/resources/syntax/syntax-template.sublime-syntax.yaml-macros
+++ b/resources/syntax/syntax-template.sublime-syntax.yaml-macros
@@ -1,0 +1,17 @@
+%YAML 1.2
+%TAG ! tag:yaml-macros:YAMLMacros.lib.include,YAMLMacros.lib.extend,embed:
+---
+# Template for Jinja-embedding syntaxes. Replace the base syntax with the
+# desired host syntax.
+
+# We will apply the following macros.
+!apply
+# Mark which base (host) syntax we shall use using its path, e.g.
+# Packages/HTML/HTML.sublime-syntax
+# This will extract the necessary information from the syntax and set them
+# as meta-variables.
+- !base_syntax path/to/syntax.sublime-syntax
+# Include the base template, whose macros will be automatically expanded upon
+# import. The resulting YAML will be merged on top of an empty dict and will be
+# written out to the name of this file, minus the `.yaml-macros` extension.
+- !include embed-base.yaml-macros


### PR DESCRIPTION
Here's my proof-of-concept take on #7.

## Changes
- I've moved the HTML embedding out of the main Jinja syntax. As a result, Jinja.sublime-syntax can now be used as a "catch-all" syntax for anything containing Jinja2 that does not have a corresponding embedding syntax.
- I've added [YAMLMacros](https://packagecontrol.io/packages/YAMLMacros) templates to easily derive new embedding languages, along with a couple of custom macros to do this.
  - The `embed-base.yaml-macros` contains a base template for any embedding language, with macros to populate the necessary fields (file extensions, base scopes, name).
  - The `embed.py` file contains custom macros to make this easier.
  - The remaining `Jinja *.sublime-syntax.yaml-macros` contain a small amount of boilerplate to instantiate a template from the syntax definition of the embedding language. Importantly, the `!base_syntax` macro loads the embedding syntax (must be installed) and populates a couple of meta-variables used in the macros from that syntax definition.
  - Any `Jinja *.sublime-syntax` file is autogenerated.
- Instead of just including the main context of the base Jinja syntax, I've opted to use a lookahead to find the beginning of a Jinja2 statement/expression/comment, and only push the base Jinja syntax when this lookahead succeeds. Reasoning is that this allows us to more easily clear the existing scopes, otherwise, if the expression occurs inside of a string in the host language, everything will inherit the string scope, which may lead to issues.

## TODO

- [x] Base syntax split.
- [x] Macros for host languages embedding Jinja
- [x] Disabling line statements for host languages using `#` as the comment.
- [ ] Syntax tests.
- [ ] More host languages?

## Screenshots
### HTML
<img width="1792" alt="Screenshot 2020-08-23 at 15 26 57" src="https://user-images.githubusercontent.com/15186467/90979417-373dcf80-e555-11ea-91df-bf3fbc5c1f5c.png">

### JSON
<img width="1792" alt="Screenshot 2020-08-23 at 15 27 15" src="https://user-images.githubusercontent.com/15186467/90979421-3d33b080-e555-11ea-922d-501d5adc56e6.png">
(The orange highlight on L5 is because of a linter, not because of the syntax)

### Shell
<img width="1792" alt="Screenshot 2020-08-23 at 15 27 24" src="https://user-images.githubusercontent.com/15186467/90979434-53da0780-e555-11ea-8d18-2ec22de576ab.png">

### Generic
<img width="1792" alt="Screenshot 2020-08-23 at 15 27 35" src="https://user-images.githubusercontent.com/15186467/90979439-5ccad900-e555-11ea-87ac-5acc3e7933fe.png">
