### PR TITLE
Add HTML and YAML syntax variants using inheritance

### DIFF
--- a/resources/syntax/HTML (Jinja).sublime-syntax
+++ b/resources/syntax/HTML (Jinja).sublime-syntax
@@ -14,10 +14,8 @@ extends: Jinja.sublime-syntax
 
 contexts:
   main:
-    # Override base syntax.
+    # Override parent syntax.
     - match: ''
       push: Packages/HTML/HTML.sublime-syntax
       with_prototype:
-        - include: comment
-        - include: statement_block
-        - include: expression_block
+        - include: base

--- a/resources/syntax/HTML (Jinja).sublime-syntax
+++ b/resources/syntax/HTML (Jinja).sublime-syntax
@@ -1,0 +1,23 @@
+%YAML 1.2
+---
+name: HTML (Jinja)
+file_extensions:
+  - html.j2
+  - html.jinja
+  - html.jinja2
+  - htm.j2
+  - htm.jinja
+  - htm.jinja2
+scope: text.html.jinja
+
+extends: Jinja.sublime-syntax
+
+contexts:
+  main:
+    # Override base syntax.
+    - match: ''
+      push: Packages/HTML/HTML.sublime-syntax
+      with_prototype:
+        - include: comment
+        - include: statement_block
+        - include: expression_block

--- a/resources/syntax/Jinja.sublime-syntax
+++ b/resources/syntax/Jinja.sublime-syntax
@@ -1,15 +1,10 @@
 %YAML 1.2
 ---
+name: Jinja
 file_extensions:
   - j2
   - jinja
   - jinja2
-  - html.j2
-  - html.jinja
-  - html.jinja2
-  - htm.j2
-  - htm.jinja
-  - htm.jinja2
 scope: text.jinja
 
 variables:
@@ -84,12 +79,10 @@ variables:
 
 contexts:
   main:
-    - match: ""
-      push: "Packages/HTML/HTML.sublime-syntax"
-      with_prototype:
-        - include: comment
-        - include: statement_block
-        - include: expression_block
+    # NOTE: Syntax variants override this context.
+    - include: comment
+    - include: statement_block
+    - include: expression_block
 
   comment:
     - include: single_line_comment

--- a/resources/syntax/Jinja.sublime-syntax
+++ b/resources/syntax/Jinja.sublime-syntax
@@ -80,6 +80,9 @@ variables:
 contexts:
   main:
     # NOTE: Syntax variants override this context.
+    - include: base
+
+  base:
     - include: comment
     - include: statement_block
     - include: expression_block

--- a/resources/syntax/YAML (Jinja).sublime-syntax
+++ b/resources/syntax/YAML (Jinja).sublime-syntax
@@ -10,10 +10,8 @@ extends: Jinja.sublime-syntax
 
 contexts:
   main:
-    # Override base syntax.
+    # Override parent syntax.
     - match: ''
       push: Packages/YAML/YAML.sublime-syntax
       with_prototype:
-        - include: comment
-        - include: statement_block
-        - include: expression_block
+        - include: base

--- a/resources/syntax/YAML (Jinja).sublime-syntax
+++ b/resources/syntax/YAML (Jinja).sublime-syntax
@@ -1,0 +1,19 @@
+%YAML 1.2
+---
+name: YAML (Jinja)
+file_extensions:
+  # Salt states.
+  - sls
+scope: source.yaml.jinja
+
+extends: Jinja.sublime-syntax
+
+contexts:
+  main:
+    # Override base syntax.
+    - match: ''
+      push: Packages/YAML/YAML.sublime-syntax
+      with_prototype:
+        - include: comment
+        - include: statement_block
+        - include: expression_block


### PR DESCRIPTION
Hi,

This PR fixes Issue #7 and aims to replace PR #10, this time using the much simpler approach of [Syntax inheritance](https://www.sublimetext.com/docs/syntax.html#inheritance), available since Sublime Text build `4075` (released on July 10, 2020).

Here are a few key points of this pull request:
- Moving HTML to a new syntax variant, keeping only Jinja related matching in the parent syntax.
- This means users can now be granular about syntax highlighting, opting for either plain `HTML`, plain `Jinja` or `HTML (Jinja)` syntax for their files.
- Adding a YAML syntax variant, which covers the highlighting of **Ansible Playbooks** and **Salt States**, both written in YAML with Jinja templating. Note that syntax does apply automatically for States (using the `.sls` extension), but not for Playbooks (which use the generic `.yml` extension).

For a quick explanation, syntax variants can be added by following those steps:
1. Create a new file for each variant, naming it `<Your language> (Jinja).sublime-syntax`.
2. Fill out the values of `name`, `file_extensions` and `scope` keys.
3. Add an `extends` key to inherit the variables and contexts from the parent syntax.
4. Override the `main` context of the parent syntax, matching both the source language and Jinja.

To make sure the parent syntax can be updated without touching the variants, I added a `base` context with in turn includes the relevant contexts.

Let me know if you would like to change things before merging.