### PR TITLE
Fix package name in resource files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BetterJinja
+# Jinja2
 
 ![LICENSE](https://img.shields.io/badge/LICENSE-MIT-green?style=for-the-badge) ![LICENSE](https://img.shields.io/badge/ST-Build%204107+-orange?style=for-the-badge&logo=sublime-text) ![Tag](https://img.shields.io/github/v/tag/Sublime-Instincts/BetterJinja?style=for-the-badge&logo=github&sort=semver) ![Downloads](https://img.shields.io/packagecontrol/dt/Jinja2?style=for-the-badge)
 ![Syntax tests](https://img.shields.io/github/workflow/status/Sublime-Instincts/BetterJinja/syntax_test?color=green&label=Syntax%20Tests&logo=github&logoColor=white&style=for-the-badge)
@@ -16,9 +16,9 @@ A Sublime Text package that offers enhanced syntax highlighting, snippets, compl
 ## Installation
 
 #### Package Control
-The best way is to install it via [Package Control](https://packagecontrol.io/). Once you have Package Control setup in Sublime Text, open the command palette and search for `Package Control: Install Package`. Search for `BetterJinja` and install it. Package Control will take care for of automatically updating the package for you if there are new releases.
+The best way is to install it via [Package Control](https://packagecontrol.io/). Once you have Package Control setup in Sublime Text, open the command palette and search for `Package Control: Install Package`. Search for `Jinja2` and install it. Package Control will take care for of automatically updating the package for you if there are new releases.
 
-You can also use `Package Control: Add Repository`. Copy the github url (without the `.git` at the end) and enter it into the input panel that pops up at the bottom when you select `Package Control: Add Repository`. Now use `Package Control: Install Package` and search for `BetterJinja` and install it.
+You can also use `Package Control: Add Repository`. Copy the github url (without the `.git` at the end) and enter it into the input panel that pops up at the bottom when you select `Package Control: Add Repository`. Now use `Package Control: Install Package` and search for `Jinja2` and install it.
 
 ## Documentation
 
@@ -64,7 +64,7 @@ If you already have these in your user settings, then just copy the Twig related
 
 ### Snippets
 
-`BetterJinja` only adds basic snippets for common code blocks. If you want more snippets, then please follow the official documentation on
+`Jinja2` only adds basic snippets for common code blocks. If you want more snippets, then please follow the official documentation on
 [snippets](https://www.sublimetext.com/docs/completions.html#snippets) and create your own.
 
 |  **Tab Trigger**  |           **Jinja Code Block**           |
@@ -84,7 +84,7 @@ If you already have these in your user settings, then just copy the Twig related
 
 If you want to ignore the snippets that are provided by default, you can use the `ignored_snippets` setting.
 
-`"ignored_snippets": ["BetterJinja/*"]`
+`"ignored_snippets": ["Jinja2/*"]`
 
 ## Issues & Feature requests.
 
@@ -94,7 +94,7 @@ Please follow the issue & feature request templates that have been setup while r
 
 ## Acknowledgements.
 
-The [syntax_test.yml](https://github.com/Sublime-Instincts/BetterTwig/.github/workflows/syntax_test.yml) is taken & used (with some modifications) from the official [Packages](https://github.com/sublimehq/Packages) repository. So full credit goes to them for it.
+The [syntax_test.yml](.github/workflows/syntax_test.yml) is taken & used (with some modifications) from the official [Packages](https://github.com/sublimehq/Packages) repository. So full credit goes to them for it.
 
 ## License
 The MIT License (MIT)

--- a/messages/install.txt
+++ b/messages/install.txt
@@ -1,14 +1,14 @@
- ____       _   _                _ _       _       
-|  _ \     | | | |              | (_)     (_)      
-| |_) | ___| |_| |_ ___ _ __    | |_ _ __  _  __ _ 
-|  _ < / _ \ __| __/ _ \ '__|   | | | '_ \| |/ _` |
-| |_) |  __/ |_| ||  __/ | | |__| | | | | | | (_| |
-|____/ \___|\__|\__\___|_|  \____/|_|_| |_| |\__,_|
-                                         _/ |      
-                                        |__/       
+      _ _       _       ___
+     | (_)     (_)     |__ \
+     | |_ _ __  _  __ _   ) |
+ _   | | | '_ \| |/ _` | / /
+| |__| | | | | | | (_| |/ /_
+ \____/|_|_| |_| |\__,_|____|
+              _/ |
+             |__/                                    by Ashwin Shenoy
 ======================================================================
 
-BetterJinja is an enhanced syntax highlighting package for Jinja
+Jinja2 is an enhanced syntax highlighting package for Jinja
 templates for Sublime Text. It also provides snippets, completions, 
 automatic indentation for Jinja code blocks and more !
 
@@ -16,7 +16,7 @@ Quick start
 -----------
 
 If you are seeing this messages, that means you have already installed 
-BetterJinja, which means any of your jinja files will already be 
+Jinja2, which means any of your jinja files will already be
 receiving syntax highlighting.
 
 The following file extensions are supported :-
@@ -33,7 +33,7 @@ The following file extensions are supported :-
 Having Problems ?
 -----------------
 
-If you encounter any problems with BetterJinja, or you think that it 
+If you encounter any problems with Jinja2, or you think that it
 can be improved to make your work easier, please log an issue with the 
 issue tracker:
 
@@ -42,6 +42,6 @@ issue tracker:
 Get in Touch
 ------------
 
-BetterJinja is developed & maintained by Ashwin Shenoy. If you have 
-any feedback regarding BetterJinja, just send a mail on 
+Jinja2 is developed & maintained by Ashwin Shenoy. If you have
+any feedback regarding Jinja2, just send a mail on
 ashwinshenoy05@gmail.com . 

--- a/resources/commands/Default.sublime-commands
+++ b/resources/commands/Default.sublime-commands
@@ -1,13 +1,13 @@
 [
     {
-        "caption": "BetterJinja: Open documentation",
+        "caption": "Jinja2: Open documentation",
         "command": "open_url",
         "args": {
             "url": "https://github.com/Sublime-Instincts/BetterJinja/blob/master/README.md"
         },
     },
     {
-        "caption": "Preferences: BetterJinja Key Bindings",
+        "caption": "Preferences: Jinja2 Key Bindings",
         "command": "edit_settings",
         "args": {
             "base_file": "${packages}/Jinja2/resources/keymaps/Default.sublime-keymap",

--- a/resources/menus/Main.sublime-menu
+++ b/resources/menus/Main.sublime-menu
@@ -12,7 +12,7 @@
                 "children":
                 [
                     {
-                        "caption": "BetterJinja",
+                        "caption": "Jinja2",
                         "children": [
                             {
                                 "caption": "Documentation",


### PR DESCRIPTION
Fixes #15

This commit replaces BetterJinja by Jinja2 in various files, which are relevant for the package to work properly as it is shipped under the latter name.

Also replaces some tokens in readme to avoid confusion.

Note: It excludes files, covered by https://github.com/Sublime-Instincts/BetterJinja/pull/20