### PR TITLE
Fix YAML key detection

### DIFF
--- a/Syntaxes/YAML/YAML (Jinja).sublime-syntax
+++ b/Syntaxes/YAML/YAML (Jinja).sublime-syntax
@@ -24,18 +24,76 @@ file_extensions:
 variables:
   ns_plain_first_plain_in: |- # c=plain-in
     (?x:
+        {{yaml_ns_plain_first_plain_in}}
+      | (?:[?:-] )?{{  # begins with interpolation
+    )
+
+  # original value from YAML
+  yaml_ns_plain_first_plain_in: |- # c=plain-in
+    (?x:
         [^\s{{c_indicator}}]
       | [?:-] [^\s{{c_flow_indicator}}]
-      | (?:[?:-] )?{{  # begins with jinja interpolation
-
     )
 
   ns_plain_first_plain_out: |- # c=plain-out
     (?x:
+        {{yaml_ns_plain_first_plain_out}}
+      | (?:[?:-] )?{{  # begins with interpolation
+    )
+
+  # original value from YAML
+  yaml_ns_plain_first_plain_out: |- # c=plain-out
+    (?x:
         [^\s{{c_indicator}}]
       | [?:-] \S
-      | (?:[?:-] )?{{  # begins with jinja interpolation
     )
+
+  _flow_key_in_lookahead: |-
+    (?x:
+      (?=
+        (
+            (?:
+              {{yaml_ns_plain_first_plain_in}}
+              | {{jinja_interpolation}}  # begins with interpolation
+            )
+            ( [^\s:{{c_flow_indicator}}]
+            | : [^\s{{c_flow_indicator}}]
+            | \s+ (?![#\s])
+            | {{jinja_interpolation}}    # ignore interpolation
+            )*
+          | \".*\" # simplified
+          | \'.*\'
+        )
+        \s*
+        :
+        (?:\s|$)
+      )
+    )
+
+  _flow_key_out_lookahead: |-
+    (?x:
+      (?=
+
+        (
+            (?:
+              {{yaml_ns_plain_first_plain_out}}
+              | {{jinja_interpolation}}  # begins with interpolation
+            )
+            ( [^\s:]
+            | : \S
+            | \s+ (?![#\s])
+            | {{jinja_interpolation}}    # ignore interpolation
+            )*
+          | \".*\" # simplified
+          | \'.*\'
+        )
+        \s*
+        :
+        (?:\s|$)
+      )
+    )
+
+  jinja_interpolation: '{{.*?}}'
 
 contexts:
 

--- a/Syntaxes/YAML/syntax_test_scopes.jinja.yaml
+++ b/Syntaxes/YAML/syntax_test_scopes.jinja.yaml
@@ -182,6 +182,22 @@ my-{{key}}: {{value}}
 #           ^ meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
 #             ^^^^^^^^^ meta.string.yaml meta.embedded.expression.jinja
 
+{{ key }}: {{ value }}
+# <- meta.mapping.key.yaml meta.string.yaml meta.embedded.expression.jinja punctuation.section.embedded.begin.jinja
+#^^^^^^^^ meta.mapping.key.yaml meta.string.yaml meta.embedded.expression.jinja
+#        ^ meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+#          ^^^^^^^^^^^ meta.string.yaml meta.embedded.expression.jinja - meta.mapping.key
+
+{{ key: }}: {{ value: }}
+# <- meta.mapping.key.yaml meta.string.yaml meta.embedded.expression.jinja punctuation.section.embedded.begin.jinja
+#^^^^^^^^^ meta.mapping.key.yaml meta.string.yaml meta.embedded.expression.jinja
+#         ^ meta.mapping.yaml punctuation.separator.key-value.mapping.yaml
+#           ^^^^^^^^^^^^ meta.string.yaml meta.embedded.expression.jinja - meta.mapping.key
+
+{{ no_key: }}
+# <- meta.string.yaml meta.embedded.expression.jinja punctuation.section.embedded.begin.jinja
+#^^^^^^^^^^^^ meta.string.yaml meta.embedded.expression.jinja - meta.mapping.key
+
 {% if true %}
 # <- meta.embedded.statement.jinja punctuation.section.embedded.begin.jinja
 #^^^^^^^^^^^^ meta.embedded.statement.jinja


### PR DESCRIPTION
Ignore interpolation content within `{{ .. }}` within key detection lookaheads.

related with: https://github.com/sublimehq/Packages/pull/4014